### PR TITLE
Update to gnome 3.30

### DIFF
--- a/io.github.GnomeMpv.json
+++ b/io.github.GnomeMpv.json
@@ -140,17 +140,6 @@
                   "sha256": "8351328cdfbcb2432e63938721dd781eb8c11ebc56e3a89d0f84576b96002c61"
                 }
               ]
-            },
-            {
-              "name": "wayland-protocols",
-              "cleanup": [ "*" ],
-              "sources": [
-                   {
-                       "type": "archive",
-                       "url": "https://wayland.freedesktop.org/releases/wayland-protocols-1.17.tar.xz",
-                       "sha256": "df1319cf9705643aea9fd16f9056f4e5b2471bd10c0cc3713d4a4cdc23d6812f"
-                   }
-              ]
             }
           ]
         }

--- a/io.github.GnomeMpv.json
+++ b/io.github.GnomeMpv.json
@@ -1,7 +1,7 @@
 {
   "app-id": "io.github.GnomeMpv",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.28",
+  "runtime-version": "3.30",
   "sdk": "org.gnome.Sdk",
   "command": "gnome-mpv",
   "finish-args": [
@@ -74,11 +74,11 @@
             {
               "name": "libv4l2",
               "cleanup": [ "/include", "/lib/*.la", "/lib/*/*.la", "/lib*/*/*/*.la", "/lib/pkgconfig", "/share/man" ],
-              "config-opts": [ "--disable-static" ],
+              "config-opts": [ "--disable-static", "--disable-bpf" ],
               "sources": [{
                 "type": "archive",
-                "url": "https://linuxtv.org/downloads/v4l-utils/v4l-utils-1.16.0.tar.bz2",
-                "sha256": "f1b425584284bac378b76331c0671dc890bd7af49c03e8a6cc0c70e57eea0bad"
+                "url": "https://linuxtv.org/downloads/v4l-utils/v4l-utils-1.16.2.tar.bz2",
+                "sha256": "6c3208c9a1c73455d30bae83096d161e57bec5008594f270a2a67df8c86d8e47"
               }]
             },
             {
@@ -115,8 +115,8 @@
                 "cleanup": [ "/bin", "/include", "/lib/pkgconfig", "/lib/*.la", "/share/man" ],
                 "sources": [{
                   "type": "archive",
-                  "url": "https://dl.tingping.se/mirror/fribidi-0.19.7.tar.bz2",
-                  "sha256": "08222a6212bbc2276a2d55c3bf370109ae4a35b689acbc66571ad2a670595a8e"
+                  "url": "https://github.com/fribidi/fribidi/releases/download/v1.0.5/fribidi-1.0.5.tar.bz2",
+                  "sha256": "6a64f2a687f5c4f203a46fa659f43dd43d1f8b845df8d723107e8a7e6158e4ce"
                 }]
               }]
             },
@@ -147,8 +147,8 @@
               "sources": [
                    {
                        "type": "archive",
-                       "url": "https://wayland.freedesktop.org/releases/wayland-protocols-1.14.tar.xz",
-                       "sha256": "9648896b2462b49b15a69b60f44656593c170c0e73121c890eb16d0c1d9376f6"
+                       "url": "https://wayland.freedesktop.org/releases/wayland-protocols-1.17.tar.xz",
+                       "sha256": "df1319cf9705643aea9fd16f9056f4e5b2471bd10c0cc3713d4a4cdc23d6812f"
                    }
               ]
             }
@@ -165,7 +165,8 @@
       "sources": [{
         "type": "git",
         "url": "https://github.com/rg3/youtube-dl.git",
-        "tag": "2018.10.05"
+        "tag": "2018.11.18",
+        "commit": "5bb04792696c41f66f2114b0cc05b01135fa1f68"
       }]
     }
   ]


### PR DESCRIPTION
Also update several dependencies:
* v4l-utils 1.16.2 (workaround build issue with '--disable-bpf' option)
* fribidi-1.0.5
* youtube-dl 2018.11.18 (add commit for better reproducibility)

The bpf from v4l-utils is known to be broken on some arches, see https://git.linuxtv.org/v4l-utils.git/commit/?id=5c213ee065ebd7a388f153a402851be8dfcfc960 for example. Let's disable it for now and investigate it later to not prevent updating the runtime.

Also remove wayland-protocols which aren't needed anymore.

I tested building and playing some videos.